### PR TITLE
add bash to "srun --pty" example

### DIFF
--- a/interactive-compute.md
+++ b/interactive-compute.md
@@ -3,7 +3,7 @@
 ## Shell Access
 
 ```
-srun --pty
+srun --pty bash
 ```
 
 


### PR DESCRIPTION
this did not work 
```
[ksa@sdf-login02 ~]$ srun --pty
srun: fatal: No command given to execute.
```

but this worked
```
[ksa@sdf-login02 ~]$ srun --pty bash
srun: job 60981 queued and waiting for resources
srun: job 60981 has been allocated resources
[ksa@rome0002 ~]$ exit
exit
[ksa@sdf-login02 ~]$
```