### PR TITLE
link to slack channel using documented API

### DIFF
--- a/contact-us.md
+++ b/contact-us.md
@@ -3,5 +3,5 @@
 | | |
 |--- |--- |
 | Email | unix-admin@slac.stanford.edu |
-| Slack | [slac.slack.com #comp-sdf](https://app.slack.com/client/T1X4J8FJ8/C01965DTG91) |
+| Slack | [slac.slack.com #comp-sdf](https://slac.slack.com/app_redirect?channel=comp-sdf) |
 


### PR DESCRIPTION
https://slac.slack.com/app_redirect?channel=comp-sdf

it's more readable, and documented here:
https://api.slack.com/reference/deep-linking#deep-linking-into-your-slack-app__opening-a-channel-by-name-or-id