### PR TITLE
clarify use of default repo

### DIFF
--- a/batch-compute.md
+++ b/batch-compute.md
@@ -59,10 +59,13 @@ cluster:
 
 As a matter of convention:
 
-- Default Slurm account = `<facility>`
+- Default Slurm account = `<facility>` [^defaultrepo]
 - Repo Slurm account = `<facility>:<repo>`
 - Slurm reservation = `<facility>:<repo>-<starttime>-<endtime>`
 
+[^defaultrepo]: Appropriate repos should be used for all jobs to allow for
+  accurate resource management and accounting. Not all facilities may have a
+  default repo.
 
 The mapping of repos to dedicated resource is dynamic. This is
 required, for example, to assign different nodes to a repo so that a


### PR DESCRIPTION
  * adding some clarification in a footnote


In lieu of official policy that is still being worked out, and will remain in flux as usage patterns change, add a footnote on use of default repo being generally discouraged.

Also LCLS is about to disable the lcls:default repo, so add a note that the default repo may not be available for all facilities. 